### PR TITLE
Fix typo in task loading app.name filter

### DIFF
--- a/crontask/management/commands/crontask.py
+++ b/crontask/management/commands/crontask.py
@@ -87,7 +87,8 @@ class Command(BaseCommand):
         their tasks with the scheduler.
         """
         for app in apps.get_app_configs():
-            if app.name == "contask":
+            if app.name == "crontask":
+                # Our heartbeat is loaded earlier
                 continue
             if app.ready:
                 try:


### PR DESCRIPTION
crontask.task is already loaded earlier in our handle() method, so we want to fix our app.name filter here.