### PR TITLE
Ensure all test cases use 'aware' times

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4,6 +4,8 @@ import zoneinfo
 import pytest
 from crontask import interval, scheduler, tasks
 
+DEFAULT_TZINFO = zoneinfo.ZoneInfo(key="Europe/Berlin")
+
 
 def test_heartbeat(caplog):
     with caplog.at_level("INFO"):
@@ -14,23 +16,19 @@ def test_heartbeat(caplog):
 def test_cron__stars():
     assert not scheduler.remove_all_jobs()
     assert tasks.cron("* * * * *")(tasks.heartbeat)
-    init = datetime.datetime(2021, 1, 1, 0, 0, 0)
+    init = datetime.datetime(2021, 1, 1, 0, 0, 0, tzinfo=DEFAULT_TZINFO)
     assert scheduler.get_jobs()[0].trigger.get_next_fire_time(
         init, init
-    ) == datetime.datetime(
-        2021, 1, 1, 0, 1, tzinfo=zoneinfo.ZoneInfo(key="Europe/Berlin")
-    )
+    ) == datetime.datetime(2021, 1, 1, 0, 1, tzinfo=DEFAULT_TZINFO)
 
 
 def test_cron__day_of_week():
     assert not scheduler.remove_all_jobs()
     assert tasks.cron("* * * * Mon")(tasks.heartbeat)
-    init = datetime.datetime(2021, 1, 1, 0, 0, 0)  # Friday
+    init = datetime.datetime(2021, 1, 1, 0, 0, 0, tzinfo=DEFAULT_TZINFO)  # Friday
     assert scheduler.get_jobs()[0].trigger.get_next_fire_time(
         init, init
-    ) == datetime.datetime(
-        2021, 1, 4, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Berlin")
-    )
+    ) == datetime.datetime(2021, 1, 4, 0, 0, tzinfo=DEFAULT_TZINFO)
 
 
 @pytest.mark.parametrize(
@@ -43,29 +41,23 @@ def test_cron__day_of_week():
 def test_cron_day_range(schedule):
     assert not scheduler.remove_all_jobs()
     assert tasks.cron(schedule)(tasks.heartbeat)
-    init = datetime.datetime(2021, 1, 1, 0, 0, 0)  # Friday
+    init = datetime.datetime(2021, 1, 1, 0, 0, 0, tzinfo=DEFAULT_TZINFO)  # Friday
     assert scheduler.get_jobs()[0].trigger.get_next_fire_time(
         init, init
-    ) == datetime.datetime(
-        2021, 1, 5, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Berlin")
-    )
-    init = datetime.datetime(2021, 1, 5, 0, 0, 0)  # Tuesday
+    ) == datetime.datetime(2021, 1, 5, 0, 0, tzinfo=DEFAULT_TZINFO)
+    init = datetime.datetime(2021, 1, 5, 0, 0, 0, tzinfo=DEFAULT_TZINFO)  # Tuesday
     assert scheduler.get_jobs()[0].trigger.get_next_fire_time(
         init, init
-    ) == datetime.datetime(
-        2021, 1, 6, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Berlin")
-    )
+    ) == datetime.datetime(2021, 1, 6, 0, 0, tzinfo=DEFAULT_TZINFO)
 
 
 def test_cron__every_15_minutes():
     assert not scheduler.remove_all_jobs()
     assert tasks.cron("*/15 * * * *")(tasks.heartbeat)
-    init = datetime.datetime(2021, 1, 1, 0, 0, 0)
+    init = datetime.datetime(2021, 1, 1, 0, 0, 0, tzinfo=DEFAULT_TZINFO)
     assert scheduler.get_jobs()[0].trigger.get_next_fire_time(
         init, init
-    ) == datetime.datetime(
-        2021, 1, 1, 0, 15, tzinfo=zoneinfo.ZoneInfo(key="Europe/Berlin")
-    )
+    ) == datetime.datetime(2021, 1, 1, 0, 15, tzinfo=DEFAULT_TZINFO)
 
 
 @pytest.mark.parametrize(
@@ -89,9 +81,7 @@ def test_cron__error(schedule):
 def test_interval__seconds():
     assert not scheduler.remove_all_jobs()
     assert interval(seconds=30)(tasks.heartbeat)
-    init = datetime.datetime(2021, 1, 1, 0, 0, 0)
+    init = datetime.datetime(2021, 1, 1, 0, 0, 0, tzinfo=DEFAULT_TZINFO)
     assert scheduler.get_jobs()[0].trigger.get_next_fire_time(
         init, init
-    ) == datetime.datetime(
-        2021, 1, 1, 0, 0, 30, tzinfo=zoneinfo.ZoneInfo(key="Europe/Berlin")
-    )
+    ) == datetime.datetime(2021, 1, 1, 0, 0, 30, tzinfo=DEFAULT_TZINFO)


### PR DESCRIPTION
If we mix 'aware' and 'naive' objects, then we're likely to have less repeatable tests. By ensuring all of our datetime objects are aware, our tests are more reliable.



My local machine is not in Europe/Berlin, so I was having trouble getting the tests to rune due to a mix of naive and aware times in the test