### PR TITLE
Fix scheduler shutdown deadlock by passing wait=False parameter

### DIFF
--- a/crontask/utils.py
+++ b/crontask/utils.py
@@ -37,9 +37,18 @@ else:
 
 
 def extend_lock(lock, scheduler):
-    """Extend the lock for a scheduler or shut it down."""
+    """Extend the lock for a scheduler or shut it down.
+
+    ``extend_lock`` is itself an APScheduler job and therefore runs inside one
+    of the scheduler's executor threads. ``scheduler.shutdown()`` defaults to
+    ``wait=True``, which makes the threadpool join every worker thread —
+    including the one this function is running in — raising
+    ``RuntimeError: cannot join current thread``. We pass ``wait=False`` so
+    shutdown is signalled asynchronously and the current thread is allowed to
+    finish unwinding.
+    """
     try:
         lock.extend(get_settings().LOCK_TIMEOUT, True)
     except LockError:
-        scheduler.shutdown()
+        scheduler.shutdown(wait=False)
         raise

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,10 @@ def test_extend_lock__error():
         utils.extend_lock(lock, scheduler)
     assert lock.extend.call_count == 1
     assert scheduler.shutdown.call_count == 1
+    # ``extend_lock`` runs inside a scheduler worker thread; shutdown must be
+    # signalled asynchronously to avoid ``RuntimeError: cannot join current
+    # thread`` from BlockingScheduler's pool executor.
+    scheduler.shutdown.assert_called_once_with(wait=False)
 
 
 class TestFakeLock:


### PR DESCRIPTION
## What's broken
When the Redis lock can't be extended, `extend_lock` calls `scheduler.shutdown()` to take the process down so it can restart and re-acquire the lock. Instead of shutting down cleanly, the call raises `RuntimeError: cannot join current thread`. The scheduler ends up half-dead: the running job never gets marked as finished, every subsequent firing is skipped with `maximum number of running instances reached (1)`, and Sentry Cron Monitoring spams "missed check-in" alerts every minute until someone restarts the pod.

```
File "/usr/local/lib/python3.13/site-packages/crontask/utils.py", line 44, in extend_lock
    scheduler.shutdown()
File "/usr/local/lib/python3.13/site-packages/apscheduler/executors/pool.py", line 33, in shutdown
    self._pool.shutdown(wait)
File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 239, in shutdown
    t.join()
File "/usr/local/lib/python3.13/threading.py", line 1088, in join
    raise RuntimeError("cannot join current thread")
RuntimeError: cannot join current thread
```

### Why
`extend_lock` runs as an APScheduler job, so it executes inside one of the threadpool's worker threads. `scheduler.shutdown()` defaults to `wait=True`, which makes the pool executor call `t.join()` on every worker, including the one currently executing `extend_lock`. A thread can't join itself, so Python raises and the shutdown bails out partway through.

### What changed
One line in `crontask/utils.py`: `scheduler.shutdown(wait=False)`. Shutdown is now signalled asynchronously and the current worker thread is free to finish unwinding on its own. The existing test in `tests/test_utils.py` was updated to assert `wait=False` is passed.